### PR TITLE
PHP 8.4 compatibility fixes

### DIFF
--- a/src/Api/CapturesApi.php
+++ b/src/Api/CapturesApi.php
@@ -101,10 +101,10 @@ class CapturesApi
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
-        $hostIndex = 0
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
+        ?int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/src/Api/OrdersApi.php
+++ b/src/Api/OrdersApi.php
@@ -107,10 +107,10 @@ class OrdersApi
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
-        $hostIndex = 0
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
+        ?int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/src/Api/RefundsApi.php
+++ b/src/Api/RefundsApi.php
@@ -86,10 +86,10 @@ class RefundsApi
      * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
-        $hostIndex = 0
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
+        ?int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/src/Model/Addon.php
+++ b/src/Model/Addon.php
@@ -260,7 +260,7 @@ class Addon implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('external_id', $data ?? [], null);
         $this->setIfExists('price', $data ?? [], null);

--- a/src/Model/Address.php
+++ b/src/Model/Address.php
@@ -314,7 +314,7 @@ class Address implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('attention', $data ?? [], null);
         $this->setIfExists('city', $data ?? [], null);

--- a/src/Model/CancelNotAllowedErrorMessage.php
+++ b/src/Model/CancelNotAllowedErrorMessage.php
@@ -254,7 +254,7 @@ class CancelNotAllowedErrorMessage implements ModelInterface, ArrayAccess, \Json
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('correlation_id', $data ?? [], null);
         $this->setIfExists('error_code', $data ?? [], null);

--- a/src/Model/Capture.php
+++ b/src/Model/Capture.php
@@ -302,7 +302,7 @@ class Capture implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('billing_address', $data ?? [], null);
         $this->setIfExists('capture_id', $data ?? [], null);

--- a/src/Model/CaptureNotAllowedErrorMessage.php
+++ b/src/Model/CaptureNotAllowedErrorMessage.php
@@ -254,7 +254,7 @@ class CaptureNotAllowedErrorMessage implements ModelInterface, ArrayAccess, \Jso
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('correlation_id', $data ?? [], null);
         $this->setIfExists('error_code', $data ?? [], null);

--- a/src/Model/CaptureObject.php
+++ b/src/Model/CaptureObject.php
@@ -272,7 +272,7 @@ class CaptureObject implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('captured_amount', $data ?? [], null);
         $this->setIfExists('description', $data ?? [], null);

--- a/src/Model/CarrierProduct.php
+++ b/src/Model/CarrierProduct.php
@@ -248,7 +248,7 @@ class CarrierProduct implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('identifier', $data ?? [], null);
         $this->setIfExists('name', $data ?? [], null);

--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -248,7 +248,7 @@ class Customer implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('date_of_birth', $data ?? [], null);
         $this->setIfExists('national_identification_number', $data ?? [], null);

--- a/src/Model/ErrorMessageDto.php
+++ b/src/Model/ErrorMessageDto.php
@@ -254,7 +254,7 @@ class ErrorMessageDto implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('correlation_id', $data ?? [], null);
         $this->setIfExists('error_code', $data ?? [], null);

--- a/src/Model/ExtendDueDateOptions.php
+++ b/src/Model/ExtendDueDateOptions.php
@@ -248,7 +248,7 @@ class ExtendDueDateOptions implements ModelInterface, ArrayAccess, \JsonSerializ
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('currency', $data ?? [], null);
         $this->setIfExists('options', $data ?? [], null);

--- a/src/Model/ExtendDueDateRequest.php
+++ b/src/Model/ExtendDueDateRequest.php
@@ -242,7 +242,7 @@ class ExtendDueDateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('number_of_days', $data ?? [], null);
     }

--- a/src/Model/InitialPaymentMethodDto.php
+++ b/src/Model/InitialPaymentMethodDto.php
@@ -254,7 +254,7 @@ class InitialPaymentMethodDto implements ModelInterface, ArrayAccess, \JsonSeria
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('description', $data ?? [], null);
         $this->setIfExists('number_of_installments', $data ?? [], null);

--- a/src/Model/Location.php
+++ b/src/Model/Location.php
@@ -260,7 +260,7 @@ class Location implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('address', $data ?? [], null);
         $this->setIfExists('id', $data ?? [], null);

--- a/src/Model/NoSuchCaptureErrorMessage.php
+++ b/src/Model/NoSuchCaptureErrorMessage.php
@@ -254,7 +254,7 @@ class NoSuchCaptureErrorMessage implements ModelInterface, ArrayAccess, \JsonSer
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('correlation_id', $data ?? [], null);
         $this->setIfExists('error_code', $data ?? [], null);

--- a/src/Model/NoSuchOrderErrorMessage.php
+++ b/src/Model/NoSuchOrderErrorMessage.php
@@ -254,7 +254,7 @@ class NoSuchOrderErrorMessage implements ModelInterface, ArrayAccess, \JsonSeria
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('correlation_id', $data ?? [], null);
         $this->setIfExists('error_code', $data ?? [], null);

--- a/src/Model/NotAllowedErrorMessage.php
+++ b/src/Model/NotAllowedErrorMessage.php
@@ -254,7 +254,7 @@ class NotAllowedErrorMessage implements ModelInterface, ArrayAccess, \JsonSerial
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('correlation_id', $data ?? [], null);
         $this->setIfExists('error_code', $data ?? [], null);

--- a/src/Model/NotFoundErrorMessage.php
+++ b/src/Model/NotFoundErrorMessage.php
@@ -254,7 +254,7 @@ class NotFoundErrorMessage implements ModelInterface, ArrayAccess, \JsonSerializ
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('correlation_id', $data ?? [], null);
         $this->setIfExists('error_code', $data ?? [], null);

--- a/src/Model/OptionDto.php
+++ b/src/Model/OptionDto.php
@@ -248,7 +248,7 @@ class OptionDto implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('amount', $data ?? [], null);
         $this->setIfExists('number_of_days', $data ?? [], null);

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -415,7 +415,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('billing_address', $data ?? [], null);
         $this->setIfExists('captured_amount', $data ?? [], null);

--- a/src/Model/OrderLine.php
+++ b/src/Model/OrderLine.php
@@ -326,7 +326,7 @@ class OrderLine implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('image_url', $data ?? [], null);
         $this->setIfExists('merchant_data', $data ?? [], null);

--- a/src/Model/ProductIdentifiers.php
+++ b/src/Model/ProductIdentifiers.php
@@ -272,7 +272,7 @@ class ProductIdentifiers implements ModelInterface, ArrayAccess, \JsonSerializab
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('brand', $data ?? [], null);
         $this->setIfExists('category_path', $data ?? [], null);

--- a/src/Model/Refund.php
+++ b/src/Model/Refund.php
@@ -278,7 +278,7 @@ class Refund implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('credit_invoice', $data ?? [], null);
         $this->setIfExists('description', $data ?? [], null);

--- a/src/Model/RefundNotAllowedErrorMessage.php
+++ b/src/Model/RefundNotAllowedErrorMessage.php
@@ -254,7 +254,7 @@ class RefundNotAllowedErrorMessage implements ModelInterface, ArrayAccess, \Json
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('correlation_id', $data ?? [], null);
         $this->setIfExists('error_code', $data ?? [], null);

--- a/src/Model/RefundObject.php
+++ b/src/Model/RefundObject.php
@@ -260,7 +260,7 @@ class RefundObject implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('description', $data ?? [], null);
         $this->setIfExists('order_lines', $data ?? [], null);

--- a/src/Model/RefundOrderLine.php
+++ b/src/Model/RefundOrderLine.php
@@ -240,7 +240,7 @@ class RefundOrderLine implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['reference'] = isset($data['reference']) ? $data['reference'] : null;
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;

--- a/src/Model/SelectedShippingOptionDto.php
+++ b/src/Model/SelectedShippingOptionDto.php
@@ -314,7 +314,7 @@ class SelectedShippingOptionDto implements ModelInterface, ArrayAccess, \JsonSer
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('carrier', $data ?? [], null);
         $this->setIfExists('carrier_product', $data ?? [], null);

--- a/src/Model/ShippingInfo.php
+++ b/src/Model/ShippingInfo.php
@@ -278,7 +278,7 @@ class ShippingInfo implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('return_shipping_company', $data ?? [], null);
         $this->setIfExists('return_tracking_number', $data ?? [], null);

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -254,7 +254,7 @@ class Subscription implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('interval', $data ?? [], null);
         $this->setIfExists('interval_count', $data ?? [], null);

--- a/src/Model/Timeslot.php
+++ b/src/Model/Timeslot.php
@@ -266,7 +266,7 @@ class Timeslot implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('cutoff', $data ?? [], null);
         $this->setIfExists('end', $data ?? [], null);

--- a/src/Model/UpdateAuthorization.php
+++ b/src/Model/UpdateAuthorization.php
@@ -254,7 +254,7 @@ class UpdateAuthorization implements ModelInterface, ArrayAccess, \JsonSerializa
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('description', $data ?? [], null);
         $this->setIfExists('order_amount', $data ?? [], null);

--- a/src/Model/UpdateConsumer.php
+++ b/src/Model/UpdateConsumer.php
@@ -248,7 +248,7 @@ class UpdateConsumer implements ModelInterface, ArrayAccess, \JsonSerializable
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('billing_address', $data ?? [], null);
         $this->setIfExists('shipping_address', $data ?? [], null);

--- a/src/Model/UpdateMerchantReferences.php
+++ b/src/Model/UpdateMerchantReferences.php
@@ -248,7 +248,7 @@ class UpdateMerchantReferences implements ModelInterface, ArrayAccess, \JsonSeri
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('merchant_reference1', $data ?? [], null);
         $this->setIfExists('merchant_reference2', $data ?? [], null);

--- a/src/Model/UpdateShippingInfo.php
+++ b/src/Model/UpdateShippingInfo.php
@@ -242,7 +242,7 @@ class UpdateShippingInfo implements ModelInterface, ArrayAccess, \JsonSerializab
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->setIfExists('shipping_info', $data ?? [], null);
     }


### PR DESCRIPTION
Fixes PHP warning "Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead."